### PR TITLE
add logic to prevent NullPointerException from being thrown when calling LocalCache.getIfPresent

### DIFF
--- a/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
+++ b/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
@@ -156,16 +156,13 @@ public class SafeRegex {
 
     @NotNull
     private static CachedRegexResult processRegex(@NotNull String regex) {
-        CachedRegexResult cached;
-        try {
-            cached = REGEX_CACHE.getIfPresent(regex);
+        CachedRegexResult cached = null;
 
-            if (cached == null) {
-                throw new NullPointerException();
-                // direct a null result to the catch logic so that it doesn't have to be written twice (yes i know it's stupid but it looks nicer)
-                // basically keep the same logic for dealing with a null result but also use that logic for dealing with a null regex
-            }
-        } catch (NullPointerException npe) {
+        if (regex != null) {
+            cached = REGEX_CACHE.getIfPresent(regex);
+        }
+
+        if (cached == null) {
             try {
                 var pattern = Pattern.compile(regex);
 
@@ -226,15 +223,13 @@ public class SafeRegex {
     }
 
     private static String cachedToRegexPattern(String address) {
-        CachedGlobResult cached;
+        CachedGlobResult cached = null;
 
-        try {
+        if (address != null) {
             cached = GLOB_CACHE.getIfPresent(address);
+        }
 
-            if (cached == null) {
-                throw new NullPointerException(); // see L176
-            }
-        } catch (NullPointerException npe) {
+        if (cached == null) {
             try {
                 cached = new CachedGlobResult(Glob.toRegexPattern(address), null);
 

--- a/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
+++ b/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
@@ -69,15 +69,9 @@ public class SafeRegex {
 
     public static void assertReplacementSafe(@NotNull String regex, @NotNull String replacement) {
         var key = ObjectObjectImmutablePair.of(regex, replacement);
-        CachedReplacementResult cached;
+        CachedReplacementResult cached = REPLACEMENT_CACHE.getIfPresent(key);
 
-        try {
-            cached = REPLACEMENT_CACHE.getIfPresent(key);
-
-            if (cached == null) {
-                throw new NullPointerException(); //see L176
-            }
-        } catch (NullPointerException npe) {
+        if (cached == null) {
             try {
                 var rcache = processRegex(regex);
                 if (rcache.isError())

--- a/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
+++ b/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
@@ -177,9 +177,13 @@ public class SafeRegex {
 
             } catch (PatternSyntaxException ex) {
                 cached = new CachedRegexResult(ex);
+            } catch (NullPointerException ex) {
+                cached = new CachedRegexResult(new PatternSyntaxException("the regex is a lie (regex is null)", "there is no regex", -1));
             }
 
-            REGEX_CACHE.put(regex, cached);
+            if (regex != null) {
+                REGEX_CACHE.put(regex, cached);
+            }
         }
 
         return cached;
@@ -235,9 +239,13 @@ public class SafeRegex {
 
             } catch (PatternSyntaxException ex) {
                 cached = new CachedGlobResult(null, ex);
+            } catch (NullPointerException npe) {
+                cached = new CachedGlobResult(null, new PatternSyntaxException("address is null", "no", -1)); // uh idk the best way to handle this
             }
 
-            GLOB_CACHE.put(address, cached);
+            if (address != null) {
+                GLOB_CACHE.put(address, cached);
+            }
         }
 
         return cached.regex;

--- a/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
+++ b/src/main/java/dev/khloeleclair/create/additionallogistics/common/SafeRegex.java
@@ -69,9 +69,15 @@ public class SafeRegex {
 
     public static void assertReplacementSafe(@NotNull String regex, @NotNull String replacement) {
         var key = ObjectObjectImmutablePair.of(regex, replacement);
-        CachedReplacementResult cached = REPLACEMENT_CACHE.getIfPresent(key);
+        CachedReplacementResult cached;
 
-        if (cached == null) {
+        try {
+            cached = REPLACEMENT_CACHE.getIfPresent(key);
+
+            if (cached == null) {
+                throw new NullPointerException(); //see L176
+            }
+        } catch (NullPointerException npe) {
             try {
                 var rcache = processRegex(regex);
                 if (rcache.isError())
@@ -156,8 +162,16 @@ public class SafeRegex {
 
     @NotNull
     private static CachedRegexResult processRegex(@NotNull String regex) {
-        CachedRegexResult cached = REGEX_CACHE.getIfPresent(regex);
-        if (cached == null) {
+        CachedRegexResult cached;
+        try {
+            cached = REGEX_CACHE.getIfPresent(regex);
+
+            if (cached == null) {
+                throw new NullPointerException();
+                // direct a null result to the catch logic so that it doesn't have to be written twice (yes i know it's stupid but it looks nicer)
+                // basically keep the same logic for dealing with a null result but also use that logic for dealing with a null regex
+            }
+        } catch (NullPointerException npe) {
             try {
                 var pattern = Pattern.compile(regex);
 
@@ -170,7 +184,7 @@ public class SafeRegex {
                         RegexTokenizer.visitNodes(node, x -> x instanceof RegexTokenizer.ReferenceNode)
                 );
 
-            } catch(PatternSyntaxException ex) {
+            } catch (PatternSyntaxException ex) {
                 cached = new CachedRegexResult(ex);
             }
 
@@ -218,13 +232,22 @@ public class SafeRegex {
     }
 
     private static String cachedToRegexPattern(String address) {
-        var cached = GLOB_CACHE.getIfPresent(address);
-        if (cached == null) {
+        CachedGlobResult cached;
+
+        try {
+            cached = GLOB_CACHE.getIfPresent(address);
+
+            if (cached == null) {
+                throw new NullPointerException(); // see L176
+            }
+        } catch (NullPointerException npe) {
             try {
                 cached = new CachedGlobResult(Glob.toRegexPattern(address), null);
-            } catch(PatternSyntaxException ex) {
+
+            } catch (PatternSyntaxException ex) {
                 cached = new CachedGlobResult(null, ex);
             }
+
             GLOB_CACHE.put(address, cached);
         }
 


### PR DESCRIPTION
this has been a problem for a while, as it is crashing in 1.3.0 alpha2 and does not seem to have changed since

the uncaught exception crashes client / server, this is logic to prevent the exception from being thrown by checking if the value is null before calling LocalCache.getIfPresent, if the value is null it uses the same logic as if LocalCache.getIfPresent returned null

!!! i will be able to test this later, has not been tested yet but it builds fine

uh i hope this makes sense i'm not great with words so please ask me if i need to clarify anything

here is a log of the error as well, if needed
[log.txt](https://github.com/user-attachments/files/23841350/log.2.txt)